### PR TITLE
fix for $this->mail_arguments to be really used in $command

### DIFF
--- a/includes/fetchMailRc.php
+++ b/includes/fetchMailRc.php
@@ -266,13 +266,14 @@ class fetchMailRc {
         
         // Generate command
         $command = sprintf(
-            'echo "poll %s with protocol %s user %s password %s" is %s %s | LANG="' . $user['language'] . '.utf8" fetchmail %s -t 10 --pidfile /tmp/fetchmail_rc-%s.pid -f - 2>&1',
+            'echo "poll %s with protocol %s user %s password %s" is %s %s | LANG="' . $user['language'] . '.utf8" fetchmail %s %s -t 10 --pidfile /tmp/fetchmail_rc-%s.pid -f - 2>&1',
             $this->mail_host,
             $this->mail_protocol,
             $this->mail_username,
             $this->get_mail_password(),
             $user['username'],
             ($this->mail_ssl == 1 ? 'ssl' : ''),
+            $this->mail_arguments,
             ($test_mode ? '--check' : ''),
             $user['username']
         );


### PR DESCRIPTION
Thanks for sharing your code! Wonderful work!
Here is a small fix in order to really use "mail_argument" in the fetchmail command. I decided to make it a commandline argument (as opposed to a fetchmail keyword, because of higher flexibility.
