### PR TITLE
Fix username and password with special characters

### DIFF
--- a/includes/fetchMailRc.php
+++ b/includes/fetchMailRc.php
@@ -266,7 +266,7 @@ class fetchMailRc {
         
         // Generate command
         $command = sprintf(
-            'echo "poll %s with protocol %s user %s password %s" is %s %s | LANG="' . $user['language'] . '.utf8" fetchmail %s %s -t 10 --pidfile /tmp/fetchmail_rc-%s.pid -f - 2>&1',
+            'echo "poll %s with protocol %s user \"%s\" password \"%s\"" is %s %s | LANG="' . $user['language'] . '.utf8" fetchmail %s %s -t 10 --pidfile /tmp/fetchmail_rc-%s.pid -f - 2>&1',
             $this->mail_host,
             $this->mail_protocol,
             $this->mail_username,


### PR DESCRIPTION
I tested the plugin, and fetchmail rejected my '=' in the password. Adding quotes is good for such special characters